### PR TITLE
Missing line from Pull Request #19

### DIFF
--- a/python/src/pipeline/pipeline.py
+++ b/python/src/pipeline/pipeline.py
@@ -2688,6 +2688,7 @@ class _FanoutHandler(webapp.RequestHandler):
     for child_pipeline in all_pipelines:
       if child_pipeline is None:
         continue
+      pipeline_key = str(child_pipeline.key())
       all_tasks.append(taskqueue.Task(
           url=context.pipeline_handler_path,
           params=dict(pipeline_key=pipeline_key),


### PR DESCRIPTION
A bad copy/paste job.

I also wanted to mention that this has nothing to do with Issue #17 - a misread on my part. It appears as if the pipeline library will already use the same queue name in which the executing task is part of - my interpretation says this should be the parent pipeline. As far as I can tell, child pipelines are inheriting the queues from their parents. Maybe an example will show this in more detail.

What PR #19 (and this) does is fixes the situation in which child pipelines were given a target to execute to but that target was not propagated when queueing the tasks.