### PR TITLE
Add zipimport compatability to ResourceHandler 

### DIFF
--- a/python/src/pipeline/status_ui.py
+++ b/python/src/pipeline/status_ui.py
@@ -20,6 +20,7 @@ import logging
 import os
 import pkgutil
 import traceback
+import zipfile
 
 from google.appengine.api import users
 from google.appengine.ext import webapp
@@ -92,14 +93,23 @@ class _StatusUiHandler(webapp.RequestHandler):
 
     relative_path, content_type = self._RESOURCE_MAP[resource]
     path = os.path.join(os.path.dirname(__file__), relative_path)
+
+    # It's possible we're inside a zipfile (zipimport).  If so,
+    # __file__ will start with 'something.zip'.
+    (possible_zipfile, zip_path) = os.path.relpath(path).split(os.sep, 1)
+    try:
+      content = zipfile.ZipFile(possible_zipfile).read(zip_path)
+    except (IOError, OSError, zipfile.BadZipfile):
+      try:
+        content = pkgutil.get_data(__name__, relative_path)
+      except AttributeError:  # Python < 2.6.
+        content = open(path, 'rb').read()
+
     if not pipeline._DEBUG:
       self.response.headers["Cache-Control"] = "public, max-age=300"
     self.response.headers["Content-Type"] = content_type
-    try:
-      data = pkgutil.get_data(__name__, relative_path)
-    except AttributeError:  # Python < 2.6.
-      data = None
-    self.response.out.write(data or open(path, 'rb').read())
+
+    self.response.out.write(content)
 
 
 class _BaseRpcHandler(webapp.RequestHandler):

--- a/python/src/pipeline/status_ui.py
+++ b/python/src/pipeline/status_ui.py
@@ -96,10 +96,10 @@ class _StatusUiHandler(webapp.RequestHandler):
 
     # It's possible we're inside a zipfile (zipimport).  If so,
     # __file__ will start with 'something.zip'.
-    (possible_zipfile, zip_path) = os.path.relpath(path).split(os.sep, 1)
-    try:
-      content = zipfile.ZipFile(possible_zipfile).read(zip_path)
-    except (IOError, OSError, zipfile.BadZipfile):
+    if ('.zip' + os.sep) in path:
+      (zip_file, zip_path) = os.path.relpath(path).split('.zip' + os.sep, 1)
+      content = zipfile.ZipFile(zip_file + '.zip').read(zip_path)
+    else:
       try:
         content = pkgutil.get_data(__name__, relative_path)
       except AttributeError:  # Python < 2.6.


### PR DESCRIPTION
Appengine supports zipimport which is described here: https://cloud.google.com/appengine/articles/django10_zipimport

Some appengine users may upload the mapreduce library within a .zip file. For example, Khan Academy has a third_party.zip file which contains this library and its source code. This confuses the ResourceHandler when it gets a path like /foo/bar/third_party.zip/mapreduce/python/src. These changes fix that and have been running in production at Khan Academy for 2.5 years.

I investigated adding a test case for this scenario, but it would be difficult since the status_test.py script imports from the mapreduce module. Maybe you could do something like add a status_test_runner.py that zips the mapreduce module, performs the approprate sys.path manipulation, and then calls status_test.py, but this seemed like overkill for such a simple change.

Basically the same thing as https://github.com/GoogleCloudPlatform/appengine-mapreduce/pull/59