### PR TITLE
Fix target propagation

### DIFF
--- a/python/src/pipeline/pipeline.py
+++ b/python/src/pipeline/pipeline.py
@@ -2901,6 +2901,7 @@ def _get_internal_status(pipeline_key=None,
       outputs: Dictionary of output slot dictionaries.
       children: List of child pipeline IDs.
       queueName: Queue on which this pipeline is running.
+      target: Target version/module for the pipeline.
       afterSlotKeys: List of Slot Ids after which this pipeline runs.
       currentAttempt: Number of the current attempt, starting at 1.
       maxAttempts: Maximum number of attempts before aborting.
@@ -2969,6 +2970,7 @@ def _get_internal_status(pipeline_key=None,
     'outputs': params['output_slots'].copy(),
     'children': [key.name() for key in pipeline_record.fanned_out],
     'queueName': params['queue_name'],
+    'target': params['target'],
     'afterSlotKeys': [str(key) for key in params['after_all']],
     'currentAttempt': pipeline_record.current_attempt + 1,
     'maxAttempts': pipeline_record.max_attempts,

--- a/python/src/pipeline/ui/status.css
+++ b/python/src/pipeline/ui/status.css
@@ -83,6 +83,7 @@ abbr {
 
 /* detail-specific styling */
 .status-param,
+.target-param,
 .retry-param {
   padding-left: 1em;
   font-size: 0.85em;
@@ -110,6 +111,7 @@ abbr {
 #detail .param-container,
 #detail .child-container,
 #detail .run-after-container,
+#detail .status-target-params,
 #detail .status-retry-params {
   margin-top: 1em;
 }

--- a/python/src/pipeline/ui/status.js
+++ b/python/src/pipeline/ui/status.js
@@ -326,6 +326,29 @@ function constructStageNode(pipelineId, infoMap, sidebar) {
     containerDiv.append(linksDiv);
   }
 
+  // Target parameters.
+  if (!sidebar) {
+    var targetParamsDiv = $('<div class="status-target-params">');
+    targetParamsDiv.append(
+        $('<div class="target-params-title">').text('Target parameters'));
+
+    var queueNameDiv = $('<div class="target-param">');
+    $('<span>').text('Queue name: ').appendTo(queueNameDiv);
+    $('<span>')
+        .text(infoMap.queueName)
+        .appendTo(queueNameDiv);
+    targetParamsDiv.append(queueNameDiv);
+
+    var targetDiv = $('<div class="target-param">');
+    $('<span>').text('Target: ').appendTo(targetDiv);
+    $('<span>')
+        .text(infoMap.target || 'Unspecified')
+        .appendTo(targetDiv);
+    targetParamsDiv.append(targetDiv);
+
+    containerDiv.append(targetParamsDiv);
+  }
+
   // Retry parameters.
   if (!sidebar) {
     var retryParamsDiv = $('<div class="status-retry-params">');


### PR DESCRIPTION
As described in the commit messages, this improves target propagation from parent to child pipelines. We deploy new versions often (i.e. several times per day). If a pipeline job is runs for a long time (i.e. an entire day), its children may run on different versions of the code since. These changes make sure that all jobs in a pipeline tree run on the same version of code.