### PR TITLE
Raise Exception when default cloud storage pipeline is not set

### DIFF
--- a/python/src/pipeline/pipeline.py
+++ b/python/src/pipeline/pipeline.py
@@ -1246,7 +1246,13 @@ def _write_json_blob(encoded_value, pipeline_id=None):
     The blobstore.BlobKey for the file that was created.
   """
 
-  default_bucket = app_identity.get_default_gcs_bucket_name() or "default"
+  default_bucket = app_identity.get_default_gcs_bucket_name()
+  if default_bucket is None:
+    raise Exception(
+      "No default cloud storage bucket has been set for this application. "
+      "This app was likely created before v1.9.0, please see: "
+      "https://cloud.google.com/appengine/docs/php/googlestorage/setup")
+
   path_components = ['/', default_bucket, "appengine_pipeline"]
   if pipeline_id:
     path_components.append(pipeline_id)

--- a/python/src/pipeline/pipeline.py
+++ b/python/src/pipeline/pipeline.py
@@ -1233,20 +1233,20 @@ def _short_repr(obj):
 
 def _write_json_blob(encoded_value, pipeline_id=None):
   """Writes a JSON encoded value to a Cloud Storage File.
-  
+
   This function will store the blob in a GCS file in the default bucket under
   the appengine_pipeline directory. Optionally using another directory level
   specified by pipeline_id
   Args:
     encoded_value: The encoded JSON string.
-    pipeline_id: A pipeline id to segment files in Cloud Storage, if none, 
+    pipeline_id: A pipeline id to segment files in Cloud Storage, if none,
       the file will be created under appengine_pipeline
 
   Returns:
     The blobstore.BlobKey for the file that was created.
   """
-  
-  default_bucket = app_identity.get_default_gcs_bucket_name()
+
+  default_bucket = app_identity.get_default_gcs_bucket_name() or "default"
   path_components = ['/', default_bucket, "appengine_pipeline"]
   if pipeline_id:
     path_components.append(pipeline_id)


### PR DESCRIPTION
Fixes #43 [`_write_json_blob`] by supplying a default bucket name when `app_identity.get_default_gcs_bucket_name()` returns `None`.

Related to changes introduced by #37.