### PR TITLE
Remove a special case where the appengine-pipeline generate task_target for default module

### DIFF
--- a/python/src/pipeline/util.py
+++ b/python/src/pipeline/util.py
@@ -63,8 +63,6 @@ def _get_task_target():
 
   version = os.environ["CURRENT_VERSION_ID"].split(".")[0]
   module = os.environ["CURRENT_MODULE_ID"]
-  if module == "default":
-    return version
   return "%s.%s" % (version, module)
 
 

--- a/python/test/util_test.py
+++ b/python/test/util_test.py
@@ -41,10 +41,10 @@ class GetTaskTargetTest(unittest.TestCase):
 
   def testGetTaskTargetDefaultModule(self):
     os.environ["CURRENT_MODULE_ID"] = "default"
-    self.assertEqual("v7", util._get_task_target())
+    self.assertEqual("v7.default", util._get_task_target())
     task = taskqueue.Task(url="/relative_url",
                           target=util._get_task_target())
-    self.assertEqual("v7", task.target)
+    self.assertEqual("v7.default", task.target)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The special case is causing a failure after a recent changes to
dev_appserver (Taskqueue 'target' made compatible with dev_appserver)
when taskqueue.py tries to parse module name.

For background see cl/126706214.